### PR TITLE
 Changing tsconfig settings to make build:mod work

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,13 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "module": "dist-mod/index.js",
   "files": [
     "dist",
-    "dist-mod",
     "src"
   ],
   "scripts": {
     "start": "STORYBOOK_MapboxAccessToken=$MapboxAccessToken start-storybook -p 6006",
     "storybook:build": "build-storybook",
-    "build:mod": "rm -rf dist-mod && tsc -m es2015 --outDir dist-mod",
     "build:es5": "rm -rf dist && tsc",
     "build": "npm-run-all build:*",
     "typecheck": "tsc --noEmit",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,7 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     "pretty": true,
-    "noImplicitAny": false,
     "jsx": "react",
-    "moduleResolution": "node",
     "lib": [
       "es2015",
       "dom"


### PR DESCRIPTION
I noticed that in LTA the :mod build is used, while it is not built automatically before publishing which led to quite some confusion.