### PR TITLE
Disabling depth test to prevent z-fighting

### DIFF
--- a/packages/core/src/AnimatedFlowLinesLayer/AnimatedFlowLinesLayer.ts
+++ b/packages/core/src/AnimatedFlowLinesLayer/AnimatedFlowLinesLayer.ts
@@ -73,6 +73,9 @@ export default class AnimatedFlowLinesLayer extends Layer {
     getTargetPosition: { type: 'accessor', value: (d: Flow) => d.targetPosition },
     getColor: { type: 'accessor', value: DEFAULT_COLOR },
     getThickness: { type: 'accessor', value: 1 },
+    parameters: {
+      depthTest: false,
+    },
   };
 
   constructor(props: Props) {

--- a/packages/core/src/FlowCirclesLayer/FlowCirclesLayer.ts
+++ b/packages/core/src/FlowCirclesLayer/FlowCirclesLayer.ts
@@ -35,6 +35,12 @@ export interface Props {
 
 class FlowCirclesLayer extends ScatterplotLayer {
   static layerName: string = 'FlowCirclesLayer';
+
+  static defaultProps = {
+    parameters: {
+      depthTest: false,
+    },
+  };
   props!: Props;
 
   constructor(props: Props) {

--- a/packages/core/src/FlowLinesLayer/FlowLinesLayer.ts
+++ b/packages/core/src/FlowLinesLayer/FlowLinesLayer.ts
@@ -52,6 +52,9 @@ class FlowLinesLayer extends Layer {
     drawOutline: true,
     outlineThickness: 1,
     outlineColor: [255, 255, 255, 255],
+    parameters: {
+      depthTest: false,
+    },
   };
   props!: Props;
 


### PR DESCRIPTION
Using Cmd+drag bearing/pitch can be changed. But that leads to issues due to z-fighting. Disabling depth testing as [described here](http://deck.gl/#/documentation/developer-guide/tips-and-tricks?section=per-layer-control-of-webgl-parameters) solves the problem.

before:
![image](https://user-images.githubusercontent.com/351828/54083852-5927a000-4329-11e9-8f21-beadf0b32770.png)

after:
![image](https://user-images.githubusercontent.com/351828/54083845-48772a00-4329-11e9-8691-d872893f35ce.png)
