### PR TITLE
Add the ability to set selectedLocationIds to null

### DIFF
--- a/packages/react/src/FlowMap.tsx
+++ b/packages/react/src/FlowMap.tsx
@@ -67,7 +67,7 @@ export default class FlowMap extends React.Component<Props, State> {
   };
 
   static getDerivedStateFromProps(props: Props, state: State): Partial<State> | null {
-    if (typeof(props.selectedLocationIds) !== 'undefined' && props.selectedLocationIds !== state.selectedLocationIds) {
+    if (props.selectedLocationIds !== state.selectedLocationIds) {
       return {
         selectedLocationIds: props.selectedLocationIds,
       };

--- a/packages/react/src/FlowMap.tsx
+++ b/packages/react/src/FlowMap.tsx
@@ -67,7 +67,7 @@ export default class FlowMap extends React.Component<Props, State> {
   };
 
   static getDerivedStateFromProps(props: Props, state: State): Partial<State> | null {
-    if (props.selectedLocationIds && props.selectedLocationIds !== state.selectedLocationIds) {
+    if (typeof(props.selectedLocationIds) !== 'undefined' && props.selectedLocationIds !== state.selectedLocationIds) {
       return {
         selectedLocationIds: props.selectedLocationIds,
       };


### PR DESCRIPTION
In the case that I want to handle manually the selectedLocationIds (I believe that's a possibility since we can pass the list as an attribute), there's no way to set selectedLocationIds to null since it checks if it's null before passing it to the state.

See https://github.com/teralytics/flowmap.gl/issues/84