### PR TITLE
ability to set tailLength for animated flowlines

### DIFF
--- a/examples/src/stories/index.tsx
+++ b/examples/src/stories/index.tsx
@@ -660,6 +660,7 @@ storiesOf('Basic', module)
       withFetchJson('flows', './data/flows-2016.json'),
     )(({ locations, flows }: any) => {
       const [thickness, setThickness] = React.useState(15);
+      const [tailLength, setTailLength] = React.useState(0.7);
       return (
         <>
           <FlowMap
@@ -668,6 +669,7 @@ storiesOf('Basic', module)
             maxFlowThickness={thickness}
             flows={flows}
             animate={true}
+            tailLength={tailLength}
             locations={locations}
             initialViewState={getViewStateForFeatures(locations, [window.innerWidth, window.innerHeight])}
             mapboxAccessToken={mapboxAccessToken}
@@ -683,6 +685,15 @@ storiesOf('Basic', module)
               min={0}
               max={30}
               onChange={evt => setThickness(+evt.currentTarget.value)}
+            />
+            <label>Tail length:</label>
+            <input
+              type="range"
+              value={tailLength}
+              min={0.01}
+              max={1}
+              step={0.1}
+              onChange={evt => setTailLength(+evt.currentTarget.value)}
             />
           </LegendBox>
         </>

--- a/packages/core/src/AnimatedFlowLinesLayer/AnimatedFlowLinesLayer.ts
+++ b/packages/core/src/AnimatedFlowLinesLayer/AnimatedFlowLinesLayer.ts
@@ -59,6 +59,7 @@ export interface Props extends LayerProps {
   outlineThickness?: number;
   currentTime?: number;
   thicknessUnit?: number;
+  tailLength?: number;
   getSourcePosition?: (d: Flow) => [number, number];
   getTargetPosition?: (d: Flow) => [number, number];
   getStaggering?: (d: Flow, info: AccessorObjectInfo) => number;
@@ -73,6 +74,7 @@ const DEFAULT_COLOR: RGBA = [0, 132, 193, 255];
 export default class AnimatedFlowLinesLayer extends Layer {
   static defaultProps = {
     currentTime: 0,
+    tailLength: 0.7,
     getSourcePosition: { type: 'accessor', value: (d: Flow) => d.sourcePosition },
     getTargetPosition: { type: 'accessor', value: (d: Flow) => d.targetPosition },
     getPickable: { type: 'accessor', value: (d: Flow) => 1.0 },
@@ -154,11 +156,12 @@ export default class AnimatedFlowLinesLayer extends Layer {
   }
 
   draw({ uniforms }: any) {
-    const { currentTime, thicknessUnit } = this.props;
+    const { currentTime, thicknessUnit, tailLength } = this.props;
     this.state.model
       .setUniforms({
         ...uniforms,
         thicknessUnit: thicknessUnit! * 4,
+        tailLength,
         currentTime,
       })
       .draw();

--- a/packages/core/src/AnimatedFlowLinesLayer/AnimatedFlowLinesLayerFragment.glsl.ts
+++ b/packages/core/src/AnimatedFlowLinesLayer/AnimatedFlowLinesLayerFragment.glsl.ts
@@ -43,6 +43,8 @@ export default `\
 
 precision highp float;
 
+uniform float tailLength;
+
 varying vec4 vColor;
 varying float sourceToTarget;
 varying vec2 uv;
@@ -50,7 +52,7 @@ varying vec2 uv;
 void main(void) {
   geometry.uv = uv;
 
-  gl_FragColor = vec4(vColor.xyz, vColor.w * smoothstep(0.3, 1.0, fract(sourceToTarget)));
+  gl_FragColor = vec4(vColor.xyz, vColor.w * smoothstep(1.0 - tailLength, 1.0, fract(sourceToTarget)));
 
   DECKGL_FILTER_COLOR(gl_FragColor, geometry);
 }

--- a/packages/core/src/FlowMapLayer.ts
+++ b/packages/core/src/FlowMapLayer.ts
@@ -67,6 +67,7 @@ export interface BasicProps extends LayerProps {
   highlightedLocationAreaId?: string;
   highlightedFlow?: Flow;
   outlineThickness?: number;
+  tailLength?: number;
   updateTriggers?: {
     getFlowLinesSourcePosition?: any;
     getFlowLinesTargetPosition?: any;
@@ -134,6 +135,7 @@ export default class FlowMapLayer extends CompositeLayer {
     maxLocationCircleSize: 15,
     outlineThickness: 1,
     showLocationAreas: true,
+    tailLength: 0.7,
   };
   props!: Props;
 
@@ -456,6 +458,7 @@ export default class FlowMapLayer extends CompositeLayer {
         this.getSubLayerProps({
           ...baseProps,
           currentTime: this.props.animationCurrentTime,
+          tailLength: this.props.tailLength,
           ...(getAnimatedFlowLineStaggering && {
             getStaggering: getAnimatedFlowLineStaggering,
           }),

--- a/packages/react/src/FlowMap.tsx
+++ b/packages/react/src/FlowMap.tsx
@@ -167,7 +167,7 @@ export default class FlowMap extends React.Component<Props, State> {
       animationCurrentTime: this.state.time,
       ...flowMapLayerProps,
       selectedLocationIds,
-      tailLength,
+      tailLength: tailLength || 0.7,
       highlightedLocationId: highlight && highlight.type === HighlightType.LOCATION ? highlight.locationId : undefined,
       highlightedLocationAreaId:
         highlight && highlight.type === HighlightType.LOCATION_AREA ? highlight.locationId : undefined,

--- a/packages/react/src/FlowMap.tsx
+++ b/packages/react/src/FlowMap.tsx
@@ -155,6 +155,7 @@ export default class FlowMap extends React.Component<Props, State> {
       mapboxAccessToken,
       mixBlendMode,
       multiselect,
+      tailLength,
       onSelected,
       onHighlighted,
       ...flowMapLayerProps
@@ -166,6 +167,7 @@ export default class FlowMap extends React.Component<Props, State> {
       animationCurrentTime: this.state.time,
       ...flowMapLayerProps,
       selectedLocationIds,
+      tailLength,
       highlightedLocationId: highlight && highlight.type === HighlightType.LOCATION ? highlight.locationId : undefined,
       highlightedLocationAreaId:
         highlight && highlight.type === HighlightType.LOCATION_AREA ? highlight.locationId : undefined,


### PR DESCRIPTION
Hi! Thanks for making this open source. This PR makes it possible to set the tail length of animated flowlines. Here's a screenshot of what animated flows look like when tailLength is set to a lower value:

![short tail](https://user-images.githubusercontent.com/3378822/85519680-f826f700-b655-11ea-8b85-5036d629ca1f.png)

And here's a live version - https://neon-ninja.github.io/flowmap.gl/iframe.html?id=basic--maxflowthickness-animated
