### PR TITLE
Fix README difference mode Storybook link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For instance, below we compare between the evening and the morning commuting beh
 <img src="./doc/morning-evening-peaks.gif" width="480" />
 
 ### Difference mode
-The layer can be used to show the [difference between two moments in time](?path=/story/basic--difference-mode).
+The layer can be used to show the [difference between two moments in time](https://teralytics.github.io/flowmap.gl/index.html?path=/story/basic--difference-mode).
 
 
 


### PR DESCRIPTION
As it was, it would point to a 404